### PR TITLE
设定pika版本约束，避免前后接口参数不一致导致代码失效

### DIFF
--- a/ml-model/requirements.txt
+++ b/ml-model/requirements.txt
@@ -1,5 +1,5 @@
 pandas 
-pika 
+pika>=0.11.0
 redis 
 sklearn
 numpy 


### PR DESCRIPTION
设定pika版本 >= 0.11.0